### PR TITLE
Add persistent database (SQLite) and models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+sqlmodel
+sqlalchemy

--- a/src/app.py
+++ b/src/app.py
@@ -1,8 +1,9 @@
 """
 High School Management System API
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+A simple FastAPI application that allows students to view and sign up
+for extracurricular activities at Mergington High School. This version uses
+SQLite via SQLModel for persistence (activities + signups).
 """
 
 from fastapi import FastAPI, HTTPException
@@ -10,6 +11,10 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+
+from sqlmodel import Session, select
+from models import Activity, Signup, create_db_and_tables, engine
+
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +24,28 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+
+@app.on_event("startup")
+def on_startup():
+    # Ensure database and tables exist
+    create_db_and_tables()
+    # Seed initial activities if none exist
+    with Session(engine) as session:
+        any_activity = session.exec(select(Activity)).first()
+        if not any_activity:
+            seed = [
+                Activity(name="Chess Club", description="Learn strategies and compete in chess tournaments", schedule="Fridays, 3:30 PM - 5:00 PM", max_participants=12),
+                Activity(name="Programming Class", description="Learn programming fundamentals and build software projects", schedule="Tuesdays and Thursdays, 3:30 PM - 4:30 PM", max_participants=20),
+                Activity(name="Gym Class", description="Physical education and sports activities", schedule="Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM", max_participants=30),
+                Activity(name="Soccer Team", description="Join the school soccer team and compete in matches", schedule="Tuesdays and Thursdays, 4:00 PM - 5:30 PM", max_participants=22),
+                Activity(name="Basketball Team", description="Practice and play basketball with the school team", schedule="Wednesdays and Fridays, 3:30 PM - 5:00 PM", max_participants=15),
+                Activity(name="Art Club", description="Explore your creativity through painting and drawing", schedule="Thursdays, 3:30 PM - 5:00 PM", max_participants=15),
+                Activity(name="Drama Club", description="Act, direct, and produce plays and performances", schedule="Mondays and Wednesdays, 4:00 PM - 5:30 PM", max_participants=20),
+                Activity(name="Math Club", description="Solve challenging problems and participate in math competitions", schedule="Tuesdays, 3:30 PM - 4:30 PM", max_participants=10),
+                Activity(name="Debate Team", description="Develop public speaking and argumentation skills", schedule="Fridays, 4:00 PM - 5:30 PM", max_participants=12),
+            ]
+            session.add_all(seed)
+            session.commit()
 
 
 @app.get("/")
@@ -85,48 +55,57 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    results = {}
+    with Session(engine) as session:
+        activities = session.exec(select(Activity)).all()
+        for a in activities:
+            signups = session.exec(select(Signup).where(Signup.activity_id == a.id)).all()
+            participants = [s.email for s in signups]
+            results[a.name] = {
+                "description": a.description,
+                "schedule": a.schedule,
+                "max_participants": a.max_participants,
+                "participants": participants,
+            }
+    return results
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    """Sign up a student for an activity (persisted)"""
+    with Session(engine) as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # Check if already signed up
+        existing = session.exec(select(Signup).where(Signup.activity_id == activity.id).where(Signup.email == email)).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        # Check capacity
+        count = session.exec(select(Signup).where(Signup.activity_id == activity.id)).count()
+        if count >= activity.max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        signup = Signup(activity_id=activity.id, email=email)
+        session.add(signup)
+        session.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    """Unregister a student from an activity (persisted)"""
+    with Session(engine) as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        signup = session.exec(select(Signup).where(Signup.activity_id == activity.id).where(Signup.email == email)).first()
+        if not signup:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        session.delete(signup)
+        session.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import List, Optional
+
+from sqlmodel import Field, Relationship, SQLModel, create_engine
+
+
+class Activity(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    description: Optional[str] = None
+    schedule: Optional[str] = None
+    max_participants: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    signups: List["Signup"] = Relationship(back_populates="activity")
+
+
+class Signup(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    activity_id: int = Field(foreign_key="activity.id")
+    email: str = Field(index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    activity: Optional[Activity] = Relationship(back_populates="signups")
+
+
+# Simple SQLite engine for local development. File will be created next to the repo root.
+engine = create_engine("sqlite:///./data.db", connect_args={"check_same_thread": False})
+
+
+def create_db_and_tables():
+    SQLModel.metadata.create_all(engine)


### PR DESCRIPTION
This PR introduces SQLite persistence using SQLModel. It adds Activity and Signup models, creates the database on startup, seeds initial activities when empty, and rewires endpoints to use the DB instead of the in-memory dict. This addresses issue #8.

Notes:
- Uses `sqlmodel` + `sqlalchemy`.
- For local development the DB file is `data.db` in the repository root.
- Next steps: add migrations, user model and authentication (issue #10).